### PR TITLE
added new client endpoint for service map/dependencies

### DIFF
--- a/service_dependencies.go
+++ b/service_dependencies.go
@@ -1,0 +1,35 @@
+/*
+ * Datadog API for Go
+ *
+ * Please see the included LICENSE file for licensing information.
+ *
+ * Copyright 2013 by authors and contributors.
+ */
+
+ package datadog
+
+ import (
+	 "encoding/json"
+	 "strconv"
+ )
+ 
+ type ServiceDependencies struct {
+	 ServiceName string
+	 Dependencies 	[]string
+ }
+ 
+ func (client *Client) GetServiceMap(env string, startTime *int, endTime *int) (&map[string]DependencyMap{}, error) {
+	 uri := "/v1/service_dependencies?" + env
+	 dependencies := &map[string]DependencyMap{}
+ 
+	 if startTime != nil && endTime != nil {
+		 uri += "&start=" + strconv.Itoa(*startTime) + "&end=" + strconv.Itoa(*endTime)
+	 }
+ 
+	 err := client.doJsonRequest("GET", uri, nil, dependencies); err != nil {
+		 return dependencies, err
+	 }
+ 
+	 return dependencies, nil
+ }
+ 

--- a/service_dependencies.go
+++ b/service_dependencies.go
@@ -13,10 +13,9 @@
 	 "strconv"
  )
  
- type ServiceDependencies struct {
-	 ServiceName string
-	 Dependencies 	[]string
- }
+ type DependencyMap struct {
+	Calls []string `json:"calls"`
+}
  
  func (client *Client) GetServiceMap(env string, startTime *int, endTime *int) (&map[string]DependencyMap{}, error) {
 	 uri := "/v1/service_dependencies?" + env


### PR DESCRIPTION
added new endpoint for [service dependencies](https://docs.datadoghq.com/api/v1/service-dependencies/). 

result:
```
{
    "wupiupi": {
        "calls": []
    },
    "trugut": {
        "calls": [
            "watto"
        ]
    },
    "tedryn": {
        "calls": []
    },
    "bodo": {
        "calls": [
            "mari",
            "kos",
            "tedryn"
        ]
    },
    "bacta": {
        "calls": []
    },
    "midi": {
        "calls": [
            "watto",
            "phasma"
        ]
    },
    "interstellar": {
        "calls": [
            "effervescing",
            "dooku",
            "watto",
            "kos"
        ]
    },
    "effervescing": {
        "calls": [
            "watto",
            "dooku"
        ]
    },
    "mari": {
        "calls": []
    },
    "dreadnought": {
        "calls": []
    },
    "phasma": {
        "calls": [
            "midi"
        ]
    },
    "kos": {
        "calls": [
            "wupiupi"
        ]
    },
    "dooku": {
        "calls": []
    },
    "effort": {
        "calls": [
            "bodo"
        ]
    },
    "watto": {
        "calls": [
            "midi",
            "trugut",
            "phasma",
            "tedryn"
        ]
    },
    "kamino": {
        "calls": [
            "bacta",
            "kos",
            "dooku",
            "dreadnought",
            "watto",
            "effervescing",
            "tedryn",
            "phasma",
            "wupiupi",
            "midi"
        ]
    }
}
```